### PR TITLE
Add dry-run option

### DIFF
--- a/jsondb.js
+++ b/jsondb.js
@@ -202,6 +202,7 @@ const buildResponseBody = (props) => {
 const processJsonOrContent = (file) => U.asyncCompose(buildResponseBody)(file);
 
 const jsondb = (
+  dryRun = false,
   process = processJsonOrContent,
   checkFile = checkJsonDb
 ) => async (ctx) => {


### PR DESCRIPTION
This is a PR for the issue #12 

There are currently no tests with `jsondb()` call in them. Also, dry run is currently the default mechanism so I think no further changes are required until we add saving data in JSON file.