### PR TITLE
Add access by index

### DIFF
--- a/jsondb.js
+++ b/jsondb.js
@@ -159,7 +159,7 @@ export const methodDelete = ({ ...props }) => {
       };
     }
   }
-  return { ...props, status: HttpStatus.BAD_REQUEST };
+  return { ...props, status: HttpStatus.NOT_FOUND };
 };
 
 const applyMethod = ({ data, ...props }) => {

--- a/jsondb.js
+++ b/jsondb.js
@@ -115,7 +115,7 @@ export const methodPut = ({ ...props }) => {
       }),
     };
   }
-  return { ...props, status: 400 };
+  return { ...props, status: HttpStatus.BAD_REQUEST };
 };
 
 export const methodPatch = ({ ...props }) => {

--- a/jsondb.js
+++ b/jsondb.js
@@ -139,8 +139,8 @@ export const methodPatch = ({ ...props }) => {
 
 export const methodDelete = ({ ...props }) => {
   const { lensPath, json } = props;
-  const path = restfulLensPath(lensPath, json);
-  const parentPath = restfulLensPath(lensPath.slice(0, -1), json);
+  const path = retrievePath(lensPath, json);
+  const parentPath = retrievePath(lensPath.slice(0, -1), json);
   const parentView = U.path(parentPath, json);
   const lastIdx = path.pop();
 
@@ -198,6 +198,39 @@ const applyGetMethod = U.when(
 );
 
 export const handleJson = U.compose(buildResponse, applyMethod, applyGetMethod);
+
+const retrievePath = (lensPath, json) => {
+  let restfulPath = restfulLensPath(lensPath, json);
+
+  return !U.isEmpty(restfulPath)
+    ? restfulPath
+    : indexLensPath(lensPath, json);
+};
+
+const indexLensPath = (lensPath, json) => {
+  let finalPath = [];
+
+  for (
+    let pathItem = null, pathCopy = [...lensPath], current = { ...json };
+    (pathItem = pathCopy.shift());
+  ) {
+    if (U.isObject(current)) {
+      current = current[pathItem];
+      finalPath.push(pathItem);
+    } else if (U.isArray(current)) {
+      const index = Number(pathItem);
+      const maybeItem = current[Number(pathItem)];
+      if (isNaN(index) || maybeItem == null) {
+        return [];
+      }
+      current = current;
+      finalPath.push(`${pathItem}`);
+    } else {
+      return [];
+    }
+  }
+  return finalPath;
+};
 
 const restfulLensPath = (lensPath, json) => {
   let finalPath = [];

--- a/tests/jsondb.test.js
+++ b/tests/jsondb.test.js
@@ -127,7 +127,7 @@ Deno.test("methodDelete", () => {
   });
 
   jsonCopy = JSON.parse(JSON.stringify(json));
-  lensPath = ["laptops", "1"];
+  lensPath = ["laptops", "1", "byindex"];
   result = methodDelete({ json: jsonCopy, method, lensPath });
   jsonCopy.laptops.splice(lensPath.slice(1), 1);
   assertEquals(result, {

--- a/tests/jsondb.test.js
+++ b/tests/jsondb.test.js
@@ -127,6 +127,14 @@ Deno.test("methodDelete", () => {
   });
 
   jsonCopy = JSON.parse(JSON.stringify(json));
+  lensPath = ["laptops", "1"];
+  result = methodDelete({ json: jsonCopy, method, lensPath });
+  jsonCopy.laptops.splice(lensPath.slice(1), 1);
+  assertEquals(result, {
+    data: { ...json, laptops: jsonCopy.laptops },
+  });
+
+  jsonCopy = JSON.parse(JSON.stringify(json));
   lensPath = ["color", "dark"];
   result = methodDelete({ json: jsonCopy, method, lensPath });
   const { dark: _, ...colorResult } = json.color;


### PR DESCRIPTION
This adds an option to do DELETE request by using indexing in the path.

For example:

```
/api/laptops/0/byindex/shipment/2/byindex
```

`byindex` after the parameter will tell the resolver that we're looking for an item with the given index in an array instead of an item with the same ID as the given parameter.